### PR TITLE
delete ApiResponse file because the file name should be camelCase

### DIFF
--- a/application/server/common/apiResponse/interface/ApiResponseHandler.ts
+++ b/application/server/common/apiResponse/interface/ApiResponseHandler.ts
@@ -1,8 +1,0 @@
-import { ApiResponseSpec } from '../definition/apiResponseSpec';
-
-export interface ApiResponseHandler {
-  createResponse<TResponse = unknown>(
-    data?: TResponse,
-  ): ApiResponseSpec<TResponse>;
-  addErrorMessages(...messages: string[]): void;
-}


### PR DESCRIPTION
unify the file name to camelCase and ApiResponse.ts is PascalCase, so this file is deleted.